### PR TITLE
fix: deltas_to_message role and message construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llms-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-stream",
  "base64",

--- a/crates/llms-sdk-ts/Cargo.toml
+++ b/crates/llms-sdk-ts/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 base64       = "0.22.1"
 file-format  = { version = "0.29.0" }
 futures-util = "0.3"
-llms-sdk     = { path = "../llms-sdk", version = "0.1.1" }
+llms-sdk     = { path = "../llms-sdk", version = "0.1.2" }
 napi         = { version = "3.0.0", features = ["serde-json", "async"] }
 napi-derive  = "3.0.0"
 schemars     = "1.2.1"

--- a/crates/llms-sdk-ts/index.js
+++ b/crates/llms-sdk-ts/index.js
@@ -80,8 +80,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-android-arm64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -96,8 +96,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-android-arm-eabi')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -116,8 +116,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-win32-x64-msvc')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -132,8 +132,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-win32-ia32-msvc')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -148,8 +148,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-win32-arm64-msvc')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
     try {
       const binding = require('@cle-does-things/llms-sdk-darwin-universal')
       const bindingPackageVersion = require('@cle-does-things/llms-sdk-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -183,8 +183,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-darwin-x64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -199,8 +199,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-darwin-arm64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -219,8 +219,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-freebsd-x64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -235,8 +235,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-freebsd-arm64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -256,8 +256,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-x64-musl')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -272,8 +272,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-x64-gnu')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -290,8 +290,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-arm64-musl')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -306,8 +306,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-arm64-gnu')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -324,8 +324,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-arm-musleabihf')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -340,8 +340,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -358,8 +358,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-loong64-musl')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -374,8 +374,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-loong64-gnu')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -392,8 +392,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-riscv64-musl')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -408,8 +408,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-riscv64-gnu')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -425,8 +425,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-linux-ppc64-gnu')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -441,8 +441,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-linux-s390x-gnu')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -461,8 +461,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-openharmony-arm64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -477,8 +477,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-openharmony-x64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -493,8 +493,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-openharmony-arm')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/crates/llms-sdk-ts/package.json
+++ b/crates/llms-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cle-does-things/llms-sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Unified interface to call OpenAI and Anthropic-compatible LLM APIs from Typescript",
   "main": "index.js",
   "repository": {

--- a/crates/llms-sdk/Cargo.toml
+++ b/crates/llms-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llms-sdk"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "MIT"
 readme = "README.md"

--- a/crates/llms-sdk/src/anthropic.rs
+++ b/crates/llms-sdk/src/anthropic.rs
@@ -1096,6 +1096,7 @@ impl AntClient {
                                                 indexed_tool_calls.entry(t.index).and_modify(|e| e.arguments += &t.delta.partial_json);
                                                 let tool_call = indexed_tool_calls.get(&t.index).expect("Tool call should have been registered by now");
                                                 let tool_delta = LLMToolDelta {
+                                                    response_id: response_id.clone().expect("Response ID should be set by now"),
                                                     tool_call_id: tool_call.id.clone(),
                                                     partial_arguments: t.delta.partial_json,
                                                     name: tool_call.name.clone(),

--- a/crates/llms-sdk/src/openai.rs
+++ b/crates/llms-sdk/src/openai.rs
@@ -780,15 +780,13 @@ impl From<OpenAIStreamingMessage> for LLMStreamingDelta {
 }
 
 fn deltas_to_message(deltas: &[LLMStreamingDelta]) -> Message {
-    let mut content = vec![];
+    let mut text = String::new();
     for delta in deltas {
-        content.push(MessagePart::Text(TextPart {
-            text: delta.delta.to_owned().unwrap_or_default(),
-        }));
+        text += delta.delta.clone().unwrap_or_default().as_ref();
     }
     Message {
-        role: MessageRole::User,
-        content,
+        role: MessageRole::Assistant,
+        content: vec![MessagePart::Text(TextPart { text })],
     }
 }
 
@@ -1359,7 +1357,8 @@ mod tests {
             },
         ];
         let message = deltas_to_message(&deltas);
-        assert_eq!(message.role, MessageRole::User);
+        assert_eq!(message.role, MessageRole::Assistant);
+        assert_eq!(message.content.len(), 1);
         let joined: String = message
             .content
             .into_iter()

--- a/crates/llms-sdk/src/openai.rs
+++ b/crates/llms-sdk/src/openai.rs
@@ -779,14 +779,20 @@ impl From<OpenAIStreamingMessage> for LLMStreamingDelta {
     }
 }
 
-fn deltas_to_message(deltas: &[LLMStreamingDelta]) -> Message {
+fn deltas_to_message(deltas: &[LLMStreamingDelta], tool_calls: Option<&[ToolCallPart]>) -> Message {
     let mut text = String::new();
     for delta in deltas {
         text += delta.delta.clone().unwrap_or_default().as_ref();
     }
+    let mut content = vec![MessagePart::Text(TextPart { text })];
+    if let Some(tcs) = tool_calls {
+        for tc in tcs {
+            content.push(MessagePart::ToolCall(tc.to_owned()));
+        }
+    }
     Message {
         role: MessageRole::Assistant,
-        content: vec![MessagePart::Text(TextPart { text })],
+        content,
     }
 }
 
@@ -901,7 +907,6 @@ impl OpenAIClient {
                 match ev {
                     Ok(event) => {
                         if event.data == "[DONE]" {
-                            let message = deltas_to_message(&deltas);
                             let mut tool_calls = None;
                             if !indexed_tool_calls.is_empty() {
                                 for (_, tc) in indexed_tool_calls.clone() {
@@ -911,11 +916,17 @@ impl OpenAIClient {
                                     tool_calls.get_or_insert_with(Vec::new).push(ToolCallPart { id: tc.id.expect("The tool call should have been registered with an ID"), name: tc.function.name.expect("The tool call should have been registered with a function name"), arguments: tc.function.arguments });
                                 }
                             }
+                            let message = deltas_to_message(&deltas, tool_calls.as_deref());
                             yield Ok(LLMStreamingResponse::Complete(LLMStreamingComplete { id: response_id.clone().unwrap(), deltas: deltas.clone(), created_at: first_created, usage: resp_usage, message, tool_calls, thinking_deltas: None }))
                         } else {
                             let json_result: Result<OpenAIStreamingMessage, serde_json::Error> = serde_json::from_str(&event.data);
                             match json_result {
                                 Ok(json) => {
+                                    if response_id.is_some() {
+
+                                    } else {
+                                        response_id = Some(json.clone().id);
+                                    }
                                     let streaming_delta = LLMStreamingDelta::from(json.clone());
                                     deltas.push(streaming_delta.clone());
                                     yield Ok(LLMStreamingResponse::Delta(streaming_delta));
@@ -924,16 +935,11 @@ impl OpenAIClient {
                                         for t in tcs {
                                             indexed_tool_calls.entry(t.index).and_modify(|v| v.function.arguments += &t.function.arguments).or_insert(t.clone());
                                             let indexd_tool_call = indexed_tool_calls.get(&t.index).unwrap();
-                                            yield Ok(LLMStreamingResponse::ToolDelta(LLMToolDelta { tool_call_id: indexd_tool_call.id.clone().expect("Tool call should have been registered with an ID"), name: indexd_tool_call.function.name.clone().expect("Tool call should have been registered with a name"), partial_arguments: t.function.arguments }))
+                                            yield Ok(LLMStreamingResponse::ToolDelta(LLMToolDelta { response_id: response_id.clone().expect("Should have a response id by now"), tool_call_id: indexd_tool_call.id.clone().expect("Tool call should have been registered with an ID"), name: indexd_tool_call.function.name.clone().expect("Tool call should have been registered with a name"), partial_arguments: t.function.arguments }))
                                         }
                                     }
                                     if let Some(u) = json.usage {
                                         resp_usage = Some(LLMUsage::from(u));
-                                    }
-                                    if response_id.is_some() {
-
-                                    } else {
-                                        response_id = Some(json.id);
                                     }
                                     if first_created.is_some() {
 
@@ -1356,7 +1362,7 @@ mod tests {
                 stop: true,
             },
         ];
-        let message = deltas_to_message(&deltas);
+        let message = deltas_to_message(&deltas, None);
         assert_eq!(message.role, MessageRole::Assistant);
         assert_eq!(message.content.len(), 1);
         let joined: String = message
@@ -1368,5 +1374,44 @@ mod tests {
             })
             .collect();
         assert_eq!(joined, "hello world");
+    }
+
+    #[test]
+    fn deltas_to_message_tool_calls() {
+        let deltas = vec![
+            LLMStreamingDelta {
+                response_id: "a".to_string(),
+                created_at: None,
+                delta: Some("hello ".to_string()),
+                stop: false,
+            },
+            LLMStreamingDelta {
+                response_id: "a".to_string(),
+                created_at: None,
+                delta: Some("world".to_string()),
+                stop: true,
+            },
+        ];
+        let tool_calls = Some(vec![ToolCallPart {
+            id: "a".to_string(),
+            arguments: "{'something': 'something'}".to_string(),
+            name: "some_tool".to_string(),
+        }]);
+        let message = deltas_to_message(&deltas, tool_calls.as_deref());
+        assert_eq!(message.role, MessageRole::Assistant);
+        assert_eq!(message.content.len(), 2);
+        for c in message.content {
+            match c {
+                MessagePart::Text(t) => {
+                    assert_eq!(t.text, "hello world");
+                }
+                MessagePart::ToolCall(tc) => {
+                    assert_eq!(tc.id, "a");
+                    assert_eq!(tc.name, "some_tool");
+                    assert_eq!(tc.arguments, "{'something': 'something'}");
+                }
+                _ => panic!("There should not be any parts apart from tool calls and texts"),
+            }
+        }
     }
 }

--- a/crates/llms-sdk/src/types.rs
+++ b/crates/llms-sdk/src/types.rs
@@ -863,6 +863,8 @@ pub struct LLMThinkingDelta {
 /// A partial tool call argument delta in a streaming response.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LLMToolDelta {
+    /// Identifier of the response this delta belongs to.
+    pub response_id: String,
     /// Identifier for the in-progress tool call.
     pub tool_call_id: String,
     /// Name of the tool being called.


### PR DESCRIPTION
- `deltas_to_message` in openai.rs converted deltas to a message with a `MessageRole::User` role and with a `TextPart` for each delta, which is not what you should expect (full text in message, assistant role)
- `response_id` in streamed tool calls
- tool calls are now reported in the `LLMStreamingComplete` message
