### PR TITLE
feat: devx improvements for node bindings

### DIFF
--- a/crates/llms-sdk-ts/README.md
+++ b/crates/llms-sdk-ts/README.md
@@ -25,7 +25,7 @@ Prebuilt binaries are included for the most common platforms. If your platform i
 ## Quick start
 
 ```typescript
-import { Llm, ApiType, MessageRole, textPart } from '@cle-does-things/llms-sdk'
+import { Llm, ApiType, MessageRole } from '@cle-does-things/llms-sdk'
 
 async function main() {
   const request = {
@@ -35,7 +35,7 @@ async function main() {
     messages: [
       {
         role: MessageRole.User,
-        content: textPart({ text: 'Hello!' }),
+        content: [{ text: 'Hello!', type: 'text' }],
       },
     ],
     maxOutputTokens: 256,
@@ -69,7 +69,7 @@ import { imagePart } from '@cle-does-things/llms-sdk'
 const message = {
   role: MessageRole.User,
   content: [
-    textPart({ text: 'Describe this image.' }),
+    { text: 'Describe this image.', type: 'text' },
     imagePart('files/cat.jpeg'), // or a Buffer, or a URL
   ],
 }
@@ -78,12 +78,12 @@ const message = {
 ### Audio (OpenAI only)
 
 ```typescript
-import { audioPart, textPart } from '@cle-does-things/llms-sdk'
+import { audioPart } from '@cle-does-things/llms-sdk'
 
 const message = {
   role: MessageRole.User,
   content: [
-    textPart({ text: 'Describe this audio.' }),
+    { text: 'Describe this audio.', type: 'text' },
     audioPart('files/audio.wav'), // or a Buffer
   ],
 }
@@ -92,12 +92,12 @@ const message = {
 ### Document (Anthropic only)
 
 ```typescript
-import { documentPart, textPart } from '@cle-does-things/llms-sdk'
+import { documentPart } from '@cle-does-things/llms-sdk'
 
 const message = {
   role: MessageRole.User,
   content: [
-    textPart({ text: 'Summarize this document.' }),
+    { text: 'Summarize this document.', type: 'text' },
     documentPart('files/file.pdf'), // or a Buffer, or a URL
   ],
 }
@@ -167,17 +167,17 @@ await llm.streamResponse(request, (err, chunk) => {
   if (!chunk) return
 
   switch (chunk.type) {
-    case 'Delta':
-      process.stdout.write(chunk.field0.delta ?? '')
+    case 'delta':
+      process.stdout.write(chunk.textDelta ?? '')
       break
-    case 'ToolDelta':
-      console.log('Tool delta:', chunk.field0)
+    case 'toolDelta':
+      console.log('Tool delta:', JSON.stringify(chunk, undefined, 2))
       break
-    case 'ThinkingDelta':
-      console.log('Thinking:', chunk.field0.delta)
+    case 'thinkingDelta':
+      console.log('Thinking:', chunk.thinkingDelta)
       break
-    case 'Complete':
-      console.log('\nDone:', chunk.field0.message)
+    case 'complete':
+      console.log('\nDone:', JSON.stringify(chunk.message, undefined, 2))
       break
   }
 })
@@ -208,7 +208,7 @@ All public types are exported from `index.d.ts`. Key interfaces include:
 - `ImagePart`, `AudioPart`, `DocumentPart` – multimodal parts
 - `Tool`, `ToolCallPart`, `ToolResultPart` – tool use
 - `OutputFormat` – structured output schema
-- `LLMStreamingResponse` – streaming discriminated union
+- `LlmStreamingResponse` – streaming discriminated union
 - `RetryPolicy` – retry configuration
 
 ## Tests

--- a/crates/llms-sdk-ts/__test__/index.spec.ts
+++ b/crates/llms-sdk-ts/__test__/index.spec.ts
@@ -16,10 +16,7 @@ import {
   type OutputFormat,
   ToolChoice,
   ReasoningEffort,
-  textPart,
-  streamingResponse,
-  LlmStreamingDelta,
-  LlmStreamingComplete,
+  TextPart,
 } from '../index'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -32,7 +29,7 @@ const FILES_DIR = resolve(__dirname, '../../llms-sdk/files')
 function textMsg(text: string): Message {
   return {
     role: MessageRole.User,
-    content: [textPart({ text })],
+    content: [{ text, type: 'text' }],
   }
 }
 
@@ -74,91 +71,69 @@ function shouldRunIntegration(): boolean {
 
 test('imagePart from file path', (t) => {
   const part = imagePart(resolve(FILES_DIR, 'cat.jpeg'))
-  t.is(part.type, 'Image')
-  // @ts-expect-error Field does not exist
-  t.is(part.field0.isBase64, true)
-  // @ts-expect-error Field does not exist
-  t.is(part.field0.mimeType, 'image/jpeg')
-  // @ts-expect-error Field does not exist
-  t.true(part.field0.data.length > 0)
+  t.is(part.type, 'image')
+  t.is(part.isBase64, true)
+  t.is(part.mimeType, 'image/jpeg')
+  t.true(part.imageData.length > 0)
 })
 
 test('imagePart from Buffer', (t) => {
   const buf = readFileSync(resolve(FILES_DIR, 'cat.jpeg'))
   const part = imagePart(buf)
-  t.is(part.type, 'Image')
-  // @ts-expect-error Field does not exist
-  t.is(part.field0.isBase64, true)
-  // @ts-expect-error Field does not exist
-  t.is(part.field0.mimeType, 'image/jpeg')
-  // @ts-expect-error Field does not exist
-  t.true(part.field0.data.length > 0)
+  t.is(part.type, 'image')
+  t.is(part.isBase64, true)
+  t.is(part.mimeType, 'image/jpeg')
+  t.true(part.imageData.length > 0)
 })
 
 test('imagePart from URL string', (t) => {
   const url = 'https://example.com/cat.jpeg'
   const part = imagePart(url)
-  t.is(part.type, 'Image')
-  // @ts-expect-error Field does not exist
-  t.is(part.field0.isBase64, false)
-  // @ts-expect-error Field does not exist
-  t.is(part.field0.mimeType, undefined)
-  // @ts-expect-error Field does not exist
-  t.is(part.field0.data, url)
+  t.is(part.type, 'image')
+  t.is(part.isBase64, false)
+  t.is(part.mimeType, undefined)
+  t.is(part.imageData, url)
 })
 
 test('audioPart from file path', (t) => {
   const part = audioPart(resolve(FILES_DIR, 'audio.wav'))
-  t.is(part.type, 'Audio')
-  // @ts-expect-error Field does not exist
-  t.is(part.field0.mimeType, 'audio/vnd.wave')
-  // @ts-expect-error Field does not exist
-  t.true(part.field0.data.length > 0)
+  t.is(part.type, 'audio')
+  t.is(part.mimeType, 'audio/vnd.wave')
+  t.true(part.audioData.length > 0)
 })
 
 test('audioPart from Buffer', (t) => {
   const buf = readFileSync(resolve(FILES_DIR, 'audio.mp3'))
   const part = audioPart(buf)
-  t.is(part.type, 'Audio')
-  // @ts-expect-error Field does not exist
-  t.is(part.field0.mimeType, 'audio/mpeg')
-  // @ts-expect-error Field does not exist
-  t.true(part.field0.data.length > 0)
+  t.is(part.type, 'audio')
+  t.is(part.mimeType, 'audio/mpeg')
+  t.true(part.audioData.length > 0)
 })
 
 test('documentPart from PDF file path', (t) => {
   const part = documentPart(resolve(FILES_DIR, 'file.pdf'))
-  t.is(part.type, 'Document')
-  // @ts-expect-error Field does not exist
-  t.is(part.field0.isBase64, true)
-  // @ts-expect-error Field does not exist
-  t.is(part.field0.mimeType, 'application/pdf')
-  // @ts-expect-error Field does not exist
-  t.true(part.field0.data.length > 0)
+  t.is(part.type, 'document')
+  t.is(part.isBase64, true)
+  t.is(part.mimeType, 'application/pdf')
+  t.true(part.documentData.length > 0)
 })
 
 test('documentPart from PDF Buffer', (t) => {
   const buf = readFileSync(resolve(FILES_DIR, 'file.pdf'))
   const part = documentPart(buf)
-  t.is(part.type, 'Document')
-  // @ts-expect-error Field does not exist
-  t.is(part.field0.isBase64, true)
-  // @ts-expect-error Field does not exist
-  t.is(part.field0.mimeType, 'application/pdf')
-  // @ts-expect-error Field does not exist
-  t.true(part.field0.data.length > 0)
+  t.is(part.type, 'document')
+  t.is(part.isBase64, true)
+  t.is(part.mimeType, 'application/pdf')
+  t.true(part.documentData.length > 0)
 })
 
 test('documentPart from URL string', (t) => {
   const url = 'https://example.com/file.pdf'
   const part = documentPart(url)
-  t.is(part.type, 'Document')
-  // @ts-expect-error Field does not exist
-  t.is(part.field0.isBase64, false)
-  // @ts-expect-error Field does not exist
-  t.is(part.field0.mimeType, undefined)
-  // @ts-expect-error Field does not exist
-  t.is(part.field0.data, url)
+  t.is(part.type, 'document')
+  t.is(part.isBase64, false)
+  t.is(part.mimeType, undefined)
+  t.is(part.documentData, url)
 })
 
 /* ------------------------------------------------------------------ */
@@ -186,7 +161,7 @@ test('OpenAI – image input', async (t) => {
   const img = imagePart(resolve(FILES_DIR, 'cat.jpeg'))
   const msg: Message = {
     role: MessageRole.User,
-    content: [textPart({ text: 'Describe this image briefly.' }), img],
+    content: [{ text: 'Describe this image briefly.', type: 'text' }, img],
   }
   const req = openaiRequest(OPENAI_MODEL, [msg])
   const llm = new Llm()
@@ -202,7 +177,7 @@ test('OpenAI – audio input', async (t) => {
   const aud = audioPart(resolve(FILES_DIR, 'audio.wav'))
   const msg: Message = {
     role: MessageRole.User,
-    content: [textPart({ text: 'Describe this audio briefly.' }), aud],
+    content: [{ text: 'Describe this audio briefly.', type: 'text' }, aud],
   }
   const req = openaiRequest('gpt-audio-1.5', [msg])
   const llm = new Llm()
@@ -233,9 +208,9 @@ test('OpenAI – structured output', async (t) => {
   }
   const llm = new Llm()
   const resp = await llm.respond(req)
-  const textPart = resp.message.content.find((c) => c.type === 'Text')
+  const textPart = resp.message.content.find((c) => c.type === 'text')
   t.truthy(textPart)
-  const parsed = JSON.parse((textPart as any).field0.text)
+  const parsed = JSON.parse((textPart as TextPart).text)
   t.is(parsed.country.toLowerCase(), 'france')
   t.true(parsed.capital.length > 0)
 })
@@ -262,7 +237,7 @@ test('OpenAI – tool use', async (t) => {
   }
   const llm = new Llm()
   const resp = await llm.respond(req)
-  const hasTool = resp.message.content.some((p) => p.type === 'ToolCall')
+  const hasTool = resp.message.content.some((p) => p.type === 'toolCall')
   t.true(hasTool)
 })
 
@@ -286,11 +261,10 @@ test('OpenAI - streaming text', async (t) => {
         return
       }
       if (!chunk) return
-      if (chunk.type === 'Delta') {
-        const resp = streamingResponse(chunk) as LlmStreamingDelta
-        if (resp.delta) deltas.push(resp.delta)
-      } else if (chunk.type === 'Complete') {
-        complete = streamingResponse(chunk) as LlmStreamingComplete
+      if (chunk.type === 'textDelta') {
+        if (chunk.textDelta) deltas.push(chunk.textDelta)
+      } else if (chunk.type === 'complete') {
+        complete = chunk
         resolve()
       }
     })
@@ -326,7 +300,7 @@ test('Anthropic – image input', async (t) => {
   const img = imagePart(resolve(FILES_DIR, 'cat.jpeg'))
   const msg: Message = {
     role: MessageRole.User,
-    content: [textPart({ text: 'Describe this image briefly.' }), img],
+    content: [{ text: 'Describe this image briefly.', type: 'text' }, img],
   }
   const req = anthropicRequest(ANTHROPIC_MODEL, [msg])
   const llm = new Llm()
@@ -342,7 +316,7 @@ test('Anthropic – document input', async (t) => {
   const doc = documentPart(resolve(FILES_DIR, 'file.pdf'))
   const msg: Message = {
     role: MessageRole.User,
-    content: [textPart({ text: 'Summarize this document briefly.' }), doc],
+    content: [{ text: 'Summarize this document briefly.', type: 'text' }, doc],
   }
   const req = anthropicRequest(ANTHROPIC_MODEL, [msg])
   const llm = new Llm()
@@ -373,9 +347,9 @@ test('Anthropic – structured output', async (t) => {
   }
   const llm = new Llm()
   const resp = await llm.respond(req)
-  const textPart = resp.message.content.find((c) => c.type === 'Text')
+  const textPart = resp.message.content.find((c) => c.type === 'text')
   t.truthy(textPart)
-  const parsed = JSON.parse((textPart as any).field0.text)
+  const parsed = JSON.parse((textPart as TextPart).text)
   t.is(parsed.country.toLowerCase(), 'france')
   t.true(parsed.capital.length > 0)
 })
@@ -405,7 +379,7 @@ test('Anthropic – tool use', async (t) => {
   }
   const llm = new Llm()
   const resp = await llm.respond(req)
-  const hasTool = resp.message.content.some((p) => p.type === 'ToolCall')
+  const hasTool = resp.message.content.some((p) => p.type === 'toolCall')
   t.true(hasTool)
 })
 
@@ -429,11 +403,10 @@ test('Anthropic - streaming text', async (t) => {
         return
       }
       if (!chunk) return
-      if (chunk.type === 'Delta') {
-        const resp = streamingResponse(chunk) as LlmStreamingDelta
-        if (resp.delta) deltas.push(resp.delta)
-      } else if (chunk.type === 'Complete') {
-        complete = streamingResponse(chunk) as LlmStreamingComplete
+      if (chunk.type === 'textDelta') {
+        if (chunk.textDelta) deltas.push(chunk.textDelta)
+      } else if (chunk.type === 'complete') {
+        complete = chunk
         resolve()
       }
     })

--- a/crates/llms-sdk-ts/index.d.ts
+++ b/crates/llms-sdk-ts/index.d.ts
@@ -33,7 +33,7 @@ export declare class Llm {
    */
   streamResponse(
     request: LlmRequest,
-    callback: (err: Error | null, chunk?: LLMStreamingResponse) => void,
+    callback: (err: Error | null, chunk?: LlmStreamingResponse) => void,
   ): Promise<void>
 }
 export type LLM = Llm
@@ -45,33 +45,35 @@ export declare const enum ApiType {
 }
 
 /**
- * Create a `MessagePart.Audio` from a file path or raw bytes.
+ * Create an `AudioPart` from a file path or raw bytes.
  *
  * @param input - Either a file path (`string`) or a `Buffer` containing audio data.
- * @returns A `MessagePart` ready to be added to a `Message`.
+ * @returns An `AudioPart` ready to be added to a `Message`.
  */
-export declare function audioPart(input: string | Buffer): MessagePart
+export declare function audioPart(input: string | Buffer): AudioPart
 
 /** Audio segment of a message. */
 export interface AudioPart {
+  type: 'audio'
   /** Base64-encoded audio data. */
-  data: string
+  audioData: string
   /** MIME type of the audio (e.g. `audio/mpeg`). */
   mimeType: string
 }
 
 /**
- * Create a `MessagePart.Document` from a URL, file path, or raw bytes.
+ * Create a `DocumentPart` from a URL, file path, or raw bytes.
  *
  * @param input - Either a URL/path (`string`) or a `Buffer` containing PDF data.
- * @returns A `MessagePart` ready to be added to a `Message`.
+ * @returns A `DocumentPart` ready to be added to a `Message`.
  */
-export declare function documentPart(input: string | Buffer): MessagePart
+export declare function documentPart(input: string | Buffer): DocumentPart
 
 /** Document segment of a message (PDF or plain text). */
 export interface DocumentPart {
+  type: 'document'
   /** Raw document data (base64-encoded) or a URL. */
-  data: string
+  documentData: string
   /** MIME type of the document, when known. */
   mimeType?: string
   /** Whether `data` is base64-encoded (`true`) or a URL (`false`). */
@@ -79,17 +81,18 @@ export interface DocumentPart {
 }
 
 /**
- * Create an `MessagePart.Image` from a URL, file path, or raw bytes.
+ * Create an `ImagePart` from a URL, file path, or raw bytes.
  *
  * @param input - Either a URL/path (`string`) or a `Buffer` containing image data.
- * @returns A `MessagePart` ready to be added to a `Message`.
+ * @returns An `ImagePart` ready to be added to a `Message`.
  */
-export declare function imagePart(input: string | Buffer): MessagePart
+export declare function imagePart(input: string | Buffer): ImagePart
 
 /** Image segment of a message. */
 export interface ImagePart {
+  type: 'image'
   /** Raw image data (base64-encoded) or a URL. */
-  data: string
+  imageData: string
   /** MIME type of the image, when known. */
   mimeType?: string
   /** Whether `data` is base64-encoded (`true`) or a URL (`false`). */
@@ -144,6 +147,7 @@ export interface LlmResponse {
 
 /** Final aggregated payload emitted at the end of a streaming response. */
 export interface LlmStreamingComplete {
+  type: 'complete'
   /** Provider-generated response identifier. */
   id: string
   /** Unix timestamp of the response, when provided by the API. */
@@ -162,35 +166,34 @@ export interface LlmStreamingComplete {
 
 /** A partial text delta in a streaming response. */
 export interface LlmStreamingDelta {
+  type: 'textDelta'
   /** Identifier of the response this delta belongs to. */
   responseId: string
   /** Unix timestamp of the response, when provided by the API. */
   createdAt?: number
   /** Chunk of generated text, if any. */
-  delta?: string
+  textDelta?: string
   /** Whether this delta signals the end of the stream. */
   stop: boolean
 }
 
 /** A single item emitted by a streaming LLM response. */
-export type LLMStreamingResponse =
-  | { type: 'Delta'; field0: LlmStreamingDelta }
-  | { type: 'ToolDelta'; field0: LlmToolDelta }
-  | { type: 'ThinkingDelta'; field0: LlmThinkingDelta }
-  | { type: 'Complete'; field0: LlmStreamingComplete }
+export type LlmStreamingResponse = LlmStreamingDelta | LlmToolDelta | LlmThinkingDelta | LlmStreamingComplete
 
 /** A partial reasoning/thinking delta in a streaming response. */
 export interface LlmThinkingDelta {
+  type: 'thinkingDelta'
   /** Identifier of the response this delta belongs to. */
   responseId: string
   /** Unix timestamp of the response, when provided by the API. */
   createdAt?: number
   /** Chunk of reasoning text, if any. */
-  delta?: string
+  thinkingDelta?: string
 }
 
 /** A partial tool call argument delta in a streaming response. */
 export interface LlmToolDelta {
+  type: 'toolDelta'
   /** Identifier for the in-progress tool call. */
   toolCallId: string
   /** Name of the tool being called. */
@@ -222,14 +225,7 @@ export interface Message {
 }
 
 /** A single item inside a [`Message`]'s content array. */
-export type MessagePart =
-  | { type: 'Text'; field0: TextPart }
-  | { type: 'Image'; field0: ImagePart }
-  | { type: 'Document'; field0: DocumentPart }
-  | { type: 'Audio'; field0: AudioPart }
-  | { type: 'ToolCall'; field0: ToolCallPart }
-  | { type: 'ToolResult'; field0: ToolResultPart }
-  | { type: 'Thinking'; field0: ThinkingPart }
+export type MessagePart = TextPart | AudioPart | DocumentPart | ImagePart | ToolCallPart | ToolResultPart | ThinkingPart
 
 /** Role of a message in the conversation. */
 export declare const enum MessageRole {
@@ -272,39 +268,15 @@ export interface RetryPolicy {
   base: number
 }
 
-/**
- * Get the streaming response out of a streamed chunk in the Llm.streamResponse method.
- *
- * @param chunk - An LLMStreamingResponse chunk
- * @returns A `LLMStreamingDelta`, `LLMToolDelta`, `LLMThinkingDelta` or a `LLMStreamingComplete` message, based on the content of the chunk.
- */
-export declare function streamingResponse(
-  chunk: LLMStreamingResponse,
-): LlmStreamingDelta | LlmToolDelta | LlmThinkingDelta | LlmStreamingComplete
-
-/**
- * Create an `MessagePart.Text` from text content.
- *
- * @param part - Text to be added to the part
- * @returns A `MessagePart` ready to be added to a `Message`.
- */
-export declare function textPart(part: TextPart): MessagePart
-
 /** Plain-text segment of a message. */
 export interface TextPart {
+  type: 'text'
   text: string
 }
 
-/**
- * Create an `MessagePart.Thinking` from a thinking trace and an optional cryptographic signature.
- *
- * @param part - thinking trace and signature.
- * @returns A `MessagePart` ready to be added to a `Message`.
- */
-export declare function thinkingPart(part: ThinkingPart): MessagePart
-
 /** A reasoning/thinking block produced by the model. */
 export interface ThinkingPart {
+  type: 'thinking'
   /** The model's internal reasoning text. */
   thinking: string
   /** Cryptographic signature verifying the reasoning, when provided. */
@@ -323,6 +295,7 @@ export interface Tool {
 
 /** A tool call issued by the model. */
 export interface ToolCallPart {
+  type: 'toolCall'
   /** Unique identifier for this tool call. */
   id: string
   /** Name of the tool being invoked. */
@@ -338,26 +311,11 @@ export declare const enum ToolChoice {
   Required = 'required',
 }
 
-/**
- * Create an `MessagePart.ToolResult` from tool result data.
- *
- * @param part - tool result data.
- * @returns A `MessagePart` ready to be added to a `Message`.
- */
-export declare function toolResultPart(part: ToolResultPart): MessagePart
-
 /** Result returned to the model after executing a tool call. */
 export interface ToolResultPart {
+  type: 'toolResult'
   /** Identifier of the original tool call this result belongs to. */
   toolCallId: string
   /** JSON-encoded result payload. */
   result: string
 }
-
-/**
- * Create an `MessagePart.ToolCall` from tool call data.
- *
- * @param part - tool call data
- * @returns A `MessagePart` ready to be added to a `Message`.
- */
-export declare function tooolCallPart(part: ToolCallPart): MessagePart

--- a/crates/llms-sdk-ts/index.js
+++ b/crates/llms-sdk-ts/index.js
@@ -80,8 +80,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-android-arm64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -96,8 +96,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-android-arm-eabi')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -116,8 +116,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-win32-x64-msvc')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -132,8 +132,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-win32-ia32-msvc')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -148,8 +148,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-win32-arm64-msvc')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
     try {
       const binding = require('@cle-does-things/llms-sdk-darwin-universal')
       const bindingPackageVersion = require('@cle-does-things/llms-sdk-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -183,8 +183,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-darwin-x64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -199,8 +199,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-darwin-arm64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -219,8 +219,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-freebsd-x64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -235,8 +235,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-freebsd-arm64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -256,8 +256,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-x64-musl')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -272,8 +272,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-x64-gnu')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -290,8 +290,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-arm64-musl')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -306,8 +306,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-arm64-gnu')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -324,8 +324,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-arm-musleabihf')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -340,8 +340,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -358,8 +358,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-loong64-musl')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -374,8 +374,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-loong64-gnu')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -392,8 +392,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-riscv64-musl')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -408,8 +408,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-riscv64-gnu')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -425,8 +425,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-linux-ppc64-gnu')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -441,8 +441,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-linux-s390x-gnu')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -461,8 +461,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-openharmony-arm64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -477,8 +477,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-openharmony-x64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -493,8 +493,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-openharmony-arm')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -565,9 +565,4 @@ module.exports.documentPart = nativeBinding.documentPart
 module.exports.imagePart = nativeBinding.imagePart
 module.exports.MessageRole = nativeBinding.MessageRole
 module.exports.ReasoningEffort = nativeBinding.ReasoningEffort
-module.exports.streamingResponse = nativeBinding.streamingResponse
-module.exports.textPart = nativeBinding.textPart
-module.exports.thinkingPart = nativeBinding.thinkingPart
 module.exports.ToolChoice = nativeBinding.ToolChoice
-module.exports.toolResultPart = nativeBinding.toolResultPart
-module.exports.tooolCallPart = nativeBinding.tooolCallPart

--- a/crates/llms-sdk-ts/package.json
+++ b/crates/llms-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cle-does-things/llms-sdk",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Unified interface to call OpenAI and Anthropic-compatible LLM APIs from Typescript",
   "main": "index.js",
   "repository": {

--- a/crates/llms-sdk-ts/src/lib.rs
+++ b/crates/llms-sdk-ts/src/lib.rs
@@ -97,7 +97,7 @@ impl LLM {
   pub async fn stream_response(
     &self,
     request: LLMRequest,
-    #[napi(ts_arg_type = "(err: Error | null, chunk?: LLMStreamingResponse) => void")]
+    #[napi(ts_arg_type = "(err: Error | null, chunk?: LlmStreamingResponse) => void")]
     callback: ThreadsafeFunction<LLMStreamingResponse, ()>,
   ) -> napi::Result<()> {
     let mut stream = self

--- a/crates/llms-sdk-ts/src/types.rs
+++ b/crates/llms-sdk-ts/src/types.rs
@@ -21,6 +21,7 @@ use llms_sdk::ToolChoice as NativeToolChoice;
 use llms_sdk::ToolResultPart as NativeToolResultPart;
 use llms_sdk::{ALLOWED_AUDIO_TYPES, ALLOWED_IMAGE_TYPES};
 use napi::bindgen_prelude::Either4;
+use napi::bindgen_prelude::Either7;
 use napi::bindgen_prelude::{Buffer, Either};
 use schemars::Schema;
 use std::fs;
@@ -127,6 +128,8 @@ impl From<ToolChoice> for NativeToolChoice {
 #[napi(object)]
 #[derive(Debug, Clone)]
 pub struct TextPart {
+  #[napi(js_name = "type", ts_type = "\"text\"")]
+  pub r#type: String,
   pub text: String,
 }
 
@@ -134,8 +137,10 @@ pub struct TextPart {
 #[napi(object)]
 #[derive(Debug, Clone)]
 pub struct ImagePart {
+  #[napi(js_name = "type", ts_type = "\"image\"")]
+  pub r#type: String,
   /// Raw image data (base64-encoded) or a URL.
-  pub data: String,
+  pub image_data: String,
   /// MIME type of the image, when known.
   pub mime_type: Option<String>,
   /// Whether `data` is base64-encoded (`true`) or a URL (`false`).
@@ -146,8 +151,10 @@ pub struct ImagePart {
 #[napi(object)]
 #[derive(Debug, Clone)]
 pub struct AudioPart {
+  #[napi(js_name = "type", ts_type = "\"audio\"")]
+  pub r#type: String,
   /// Base64-encoded audio data.
-  pub data: String,
+  pub audio_data: String,
   /// MIME type of the audio (e.g. `audio/mpeg`).
   pub mime_type: String,
 }
@@ -156,8 +163,10 @@ pub struct AudioPart {
 #[napi(object)]
 #[derive(Debug, Clone)]
 pub struct DocumentPart {
+  #[napi(js_name = "type", ts_type = "\"document\"")]
+  pub r#type: String,
   /// Raw document data (base64-encoded) or a URL.
-  pub data: String,
+  pub document_data: String,
   /// MIME type of the document, when known.
   pub mime_type: Option<String>,
   /// Whether `data` is base64-encoded (`true`) or a URL (`false`).
@@ -168,6 +177,8 @@ pub struct DocumentPart {
 #[napi(object)]
 #[derive(Debug, Clone)]
 pub struct ToolCallPart {
+  #[napi(js_name = "type", ts_type = "\"toolCall\"")]
+  pub r#type: String,
   /// Unique identifier for this tool call.
   pub id: String,
   /// Name of the tool being invoked.
@@ -180,6 +191,8 @@ pub struct ToolCallPart {
 #[napi(object)]
 #[derive(Debug, Clone)]
 pub struct ToolResultPart {
+  #[napi(js_name = "type", ts_type = "\"toolResult\"")]
+  pub r#type: String,
   /// Identifier of the original tool call this result belongs to.
   pub tool_call_id: String,
   /// JSON-encoded result payload.
@@ -190,6 +203,8 @@ pub struct ToolResultPart {
 #[napi(object)]
 #[derive(Debug, Clone)]
 pub struct ThinkingPart {
+  #[napi(js_name = "type", ts_type = "\"thinking\"")]
+  pub r#type: String,
   /// The model's internal reasoning text.
   pub thinking: String,
   /// Cryptographic signature verifying the reasoning, when provided.
@@ -197,46 +212,48 @@ pub struct ThinkingPart {
 }
 
 /// A single item inside a [`Message`]'s content array.
-#[napi]
+#[napi(transparent)]
 #[derive(Debug, Clone)]
-pub enum MessagePart {
-  Text(TextPart),
-  Image(ImagePart),
-  Document(DocumentPart),
-  Audio(AudioPart),
-  ToolCall(ToolCallPart),
-  ToolResult(ToolResultPart),
-  Thinking(ThinkingPart),
-}
+pub struct MessagePart(
+  pub  Either7<
+    TextPart,
+    AudioPart,
+    DocumentPart,
+    ImagePart,
+    ToolCallPart,
+    ToolResultPart,
+    ThinkingPart,
+  >,
+);
 
 impl From<MessagePart> for NativeMessagePart {
   fn from(value: MessagePart) -> Self {
-    match value {
-      MessagePart::Text(t) => NativeMessagePart::Text(NativeTextPart { text: t.text }),
-      MessagePart::Audio(a) => NativeMessagePart::Audio(NativeAudioPart {
-        data: a.data,
+    match value.0 {
+      Either7::A(t) => NativeMessagePart::Text(NativeTextPart { text: t.text }),
+      Either7::B(a) => NativeMessagePart::Audio(NativeAudioPart {
+        data: a.audio_data,
         mime_type: a.mime_type,
       }),
-      MessagePart::Document(d) => NativeMessagePart::Document(NativeDocumentPart {
-        data: d.data,
+      Either7::C(d) => NativeMessagePart::Document(NativeDocumentPart {
+        data: d.document_data,
         mime_type: d.mime_type,
         is_base64: d.is_base64,
       }),
-      MessagePart::Image(i) => NativeMessagePart::Image(NativeImagePart {
-        data: i.data,
+      Either7::D(i) => NativeMessagePart::Image(NativeImagePart {
+        data: i.image_data,
         mime_type: i.mime_type,
         is_base64: i.is_base64,
       }),
-      MessagePart::ToolCall(tc) => NativeMessagePart::ToolCall(NativeToolCallPart {
+      Either7::E(tc) => NativeMessagePart::ToolCall(NativeToolCallPart {
         id: tc.id,
         arguments: tc.arguments,
         name: tc.name,
       }),
-      MessagePart::ToolResult(tr) => NativeMessagePart::ToolResult(NativeToolResultPart {
+      Either7::F(tr) => NativeMessagePart::ToolResult(NativeToolResultPart {
         tool_call_id: tr.tool_call_id,
         result: tr.result,
       }),
-      MessagePart::Thinking(t) => NativeMessagePart::Thinking(NativeThinkingPart {
+      Either7::G(t) => NativeMessagePart::Thinking(NativeThinkingPart {
         thinking: t.thinking,
         signature: t.signature,
       }),
@@ -247,54 +264,64 @@ impl From<MessagePart> for NativeMessagePart {
 impl From<NativeMessagePart> for MessagePart {
   fn from(value: NativeMessagePart) -> Self {
     match value {
-      NativeMessagePart::Audio(a) => Self::Audio(AudioPart {
-        data: a.data,
+      NativeMessagePart::Audio(a) => Self(Either7::B(AudioPart {
+        r#type: "audio".to_string(),
+        audio_data: a.data,
         mime_type: a.mime_type,
-      }),
-      NativeMessagePart::Document(d) => Self::Document(DocumentPart {
-        data: d.data,
+      })),
+      NativeMessagePart::Document(d) => Self(Either7::C(DocumentPart {
+        r#type: "document".to_string(),
+        document_data: d.data,
         mime_type: d.mime_type,
         is_base64: d.is_base64,
-      }),
-      NativeMessagePart::Image(i) => Self::Image(ImagePart {
-        data: i.data,
+      })),
+      NativeMessagePart::Image(i) => Self(Either7::D(ImagePart {
+        r#type: "image".to_string(),
+        image_data: i.data,
         mime_type: i.mime_type,
         is_base64: i.is_base64,
-      }),
-      NativeMessagePart::Text(t) => Self::Text(TextPart { text: t.text }),
-      NativeMessagePart::Thinking(t) => Self::Thinking(ThinkingPart {
+      })),
+      NativeMessagePart::Text(t) => Self(Either7::A(TextPart {
+        text: t.text,
+        r#type: "text".to_string(),
+      })),
+      NativeMessagePart::Thinking(t) => Self(Either7::G(ThinkingPart {
+        r#type: "thinking".to_string(),
         thinking: t.thinking,
         signature: t.signature,
-      }),
-      NativeMessagePart::ToolCall(tc) => Self::ToolCall(ToolCallPart {
+      })),
+      NativeMessagePart::ToolCall(tc) => Self(Either7::E(ToolCallPart {
+        r#type: "toolCall".to_string(),
         id: tc.id,
         name: tc.name,
         arguments: tc.arguments,
-      }),
-      NativeMessagePart::ToolResult(tr) => Self::ToolResult(ToolResultPart {
+      })),
+      NativeMessagePart::ToolResult(tr) => Self(Either7::F(ToolResultPart {
+        r#type: "toolResult".to_string(),
         tool_call_id: tr.tool_call_id,
         result: tr.result,
-      }),
+      })),
       _ => unreachable!("Should not reach this arm"),
     }
   }
 }
 
-/// Create an `MessagePart.Image` from a URL, file path, or raw bytes.
+/// Create an `ImagePart` from a URL, file path, or raw bytes.
 ///
 /// @param input - Either a URL/path (`string`) or a `Buffer` containing image data.
-/// @returns A `MessagePart` ready to be added to a `Message`.
+/// @returns An `ImagePart` ready to be added to a `Message`.
 #[napi]
-pub fn image_part(input: Either<String, Buffer>) -> napi::Result<MessagePart> {
+pub fn image_part(input: Either<String, Buffer>) -> napi::Result<ImagePart> {
   match input {
     Either::A(s) => match Url::parse(&s) {
       Ok(u) => {
         if matches!(u.scheme(), "http" | "https") {
-          Ok(MessagePart::Image(ImagePart {
-            data: s,
+          Ok(ImagePart {
+            r#type: "image".to_string(),
+            image_data: s,
             mime_type: None,
             is_base64: false,
-          }))
+          })
         } else {
           let data = fs::read(&s)?;
           let format = file_format::FileFormat::from_bytes(&data);
@@ -308,11 +335,12 @@ pub fn image_part(input: Either<String, Buffer>) -> napi::Result<MessagePart> {
               ),
             ));
           }
-          Ok(MessagePart::Image(ImagePart {
-            data: BASE64_STANDARD.encode(&data),
+          Ok(ImagePart {
+            r#type: "image".to_string(),
+            image_data: BASE64_STANDARD.encode(&data),
             mime_type: Some(format.media_type().to_owned()),
             is_base64: true,
-          }))
+          })
         }
       }
       Err(_) => {
@@ -328,11 +356,12 @@ pub fn image_part(input: Either<String, Buffer>) -> napi::Result<MessagePart> {
             ),
           ));
         }
-        Ok(MessagePart::Image(ImagePart {
-          data: BASE64_STANDARD.encode(&data),
+        Ok(ImagePart {
+          r#type: "image".to_string(),
+          image_data: BASE64_STANDARD.encode(&data),
           mime_type: Some(format.media_type().to_owned()),
           is_base64: true,
-        }))
+        })
       }
     },
     Either::B(buf) => {
@@ -348,30 +377,32 @@ pub fn image_part(input: Either<String, Buffer>) -> napi::Result<MessagePart> {
           ),
         ));
       }
-      Ok(MessagePart::Image(ImagePart {
-        data: BASE64_STANDARD.encode(&data),
+      Ok(ImagePart {
+        r#type: "image".to_string(),
+        image_data: BASE64_STANDARD.encode(&data),
         mime_type: Some(format.media_type().to_owned()),
         is_base64: true,
-      }))
+      })
     }
   }
 }
 
-/// Create a `MessagePart.Document` from a URL, file path, or raw bytes.
+/// Create a `DocumentPart` from a URL, file path, or raw bytes.
 ///
 /// @param input - Either a URL/path (`string`) or a `Buffer` containing PDF data.
-/// @returns A `MessagePart` ready to be added to a `Message`.
+/// @returns A `DocumentPart` ready to be added to a `Message`.
 #[napi]
-pub fn document_part(input: Either<String, Buffer>) -> napi::Result<MessagePart> {
+pub fn document_part(input: Either<String, Buffer>) -> napi::Result<DocumentPart> {
   match input {
     Either::A(s) => match Url::parse(&s) {
       Ok(u) => {
         if matches!(u.scheme(), "http" | "https") {
-          Ok(MessagePart::Document(DocumentPart {
-            data: s,
+          Ok(DocumentPart {
+            r#type: "document".to_string(),
+            document_data: s,
             mime_type: None,
             is_base64: false,
-          }))
+          })
         } else {
           let format = file_format::FileFormat::from_file(&s).map_err(|e| {
             napi::Error::new(
@@ -381,18 +412,20 @@ pub fn document_part(input: Either<String, Buffer>) -> napi::Result<MessagePart>
           })?;
           if format.media_type() == "application/pdf" {
             let data = fs::read(&s)?;
-            Ok(MessagePart::Document(DocumentPart {
-              data: BASE64_STANDARD.encode(data),
+            Ok(DocumentPart {
+              r#type: "document".to_string(),
+              document_data: BASE64_STANDARD.encode(data),
               mime_type: Some("application/pdf".to_string()),
               is_base64: true,
-            }))
+            })
           } else if format.media_type().starts_with("text/") {
             let data = fs::read_to_string(&s)?;
-            Ok(MessagePart::Document(DocumentPart {
-              data,
+            Ok(DocumentPart {
+              r#type: "document".to_string(),
+              document_data: data,
               mime_type: Some("text/plain".to_string()),
               is_base64: false,
-            }))
+            })
           } else {
             Err(napi::Error::new(
               napi::Status::InvalidArg,
@@ -413,18 +446,20 @@ pub fn document_part(input: Either<String, Buffer>) -> napi::Result<MessagePart>
         })?;
         if format.media_type() == "application/pdf" {
           let data = fs::read(&s)?;
-          Ok(MessagePart::Document(DocumentPart {
-            data: BASE64_STANDARD.encode(data),
+          Ok(DocumentPart {
+            r#type: "document".to_string(),
+            document_data: BASE64_STANDARD.encode(data),
             mime_type: Some("application/pdf".to_string()),
             is_base64: true,
-          }))
+          })
         } else if format.media_type().starts_with("text/") {
           let data = fs::read_to_string(&s)?;
-          Ok(MessagePart::Document(DocumentPart {
-            data,
+          Ok(DocumentPart {
+            r#type: "document".to_string(),
+            document_data: data,
             mime_type: Some("text/plain".to_string()),
             is_base64: false,
-          }))
+          })
         } else {
           Err(napi::Error::new(
             napi::Status::InvalidArg,
@@ -448,21 +483,22 @@ pub fn document_part(input: Either<String, Buffer>) -> napi::Result<MessagePart>
           ),
         ));
       }
-      Ok(MessagePart::Document(DocumentPart {
-        data: BASE64_STANDARD.encode(&data),
+      Ok(DocumentPart {
+        r#type: "document".to_string(),
+        document_data: BASE64_STANDARD.encode(&data),
         mime_type: Some(format.media_type().to_owned()),
         is_base64: true,
-      }))
+      })
     }
   }
 }
 
-/// Create a `MessagePart.Audio` from a file path or raw bytes.
+/// Create an `AudioPart` from a file path or raw bytes.
 ///
 /// @param input - Either a file path (`string`) or a `Buffer` containing audio data.
-/// @returns A `MessagePart` ready to be added to a `Message`.
+/// @returns An `AudioPart` ready to be added to a `Message`.
 #[napi]
-pub fn audio_part(input: Either<String, Buffer>) -> napi::Result<MessagePart> {
+pub fn audio_part(input: Either<String, Buffer>) -> napi::Result<AudioPart> {
   let data: Vec<u8> = match input {
     Either::A(s) => fs::read(&s)?,
     Either::B(buf) => buf.into(),
@@ -478,46 +514,11 @@ pub fn audio_part(input: Either<String, Buffer>) -> napi::Result<MessagePart> {
       ),
     ));
   }
-  Ok(MessagePart::Audio(AudioPart {
-    data: BASE64_STANDARD.encode(&data),
+  Ok(AudioPart {
+    r#type: "audio".to_string(),
+    audio_data: BASE64_STANDARD.encode(&data),
     mime_type: format.media_type().to_owned(),
-  }))
-}
-
-#[napi]
-/// Create an `MessagePart.Text` from text content.
-///
-/// @param part - Text to be added to the part
-/// @returns A `MessagePart` ready to be added to a `Message`.
-pub fn text_part(part: TextPart) -> MessagePart {
-  MessagePart::Text(part)
-}
-
-#[napi]
-/// Create an `MessagePart.ToolCall` from tool call data.
-///
-/// @param part - tool call data
-/// @returns A `MessagePart` ready to be added to a `Message`.
-pub fn toool_call_part(part: ToolCallPart) -> MessagePart {
-  MessagePart::ToolCall(part)
-}
-
-#[napi]
-/// Create an `MessagePart.ToolResult` from tool result data.
-///
-/// @param part - tool result data.
-/// @returns A `MessagePart` ready to be added to a `Message`.
-pub fn tool_result_part(part: ToolResultPart) -> MessagePart {
-  MessagePart::ToolResult(part)
-}
-
-#[napi]
-/// Create an `MessagePart.Thinking` from a thinking trace and an optional cryptographic signature.
-///
-/// @param part - thinking trace and signature.
-/// @returns A `MessagePart` ready to be added to a `Message`.
-pub fn thinking_part(part: ThinkingPart) -> MessagePart {
-  MessagePart::Thinking(part)
+  })
 }
 
 /// A single turn in the conversation.
@@ -728,12 +729,14 @@ impl From<NativeLLMResponse> for LLMResponse {
 #[napi(object)]
 #[derive(Debug, Clone)]
 pub struct LLMStreamingDelta {
+  #[napi(js_name = "type", ts_type = "\"textDelta\"")]
+  pub r#type: String,
   /// Identifier of the response this delta belongs to.
   pub response_id: String,
   /// Unix timestamp of the response, when provided by the API.
   pub created_at: Option<u32>,
   /// Chunk of generated text, if any.
-  pub delta: Option<String>,
+  pub text_delta: Option<String>,
   /// Whether this delta signals the end of the stream.
   pub stop: bool,
 }
@@ -741,9 +744,10 @@ pub struct LLMStreamingDelta {
 impl From<NativeLLMStreamingDelta> for LLMStreamingDelta {
   fn from(value: NativeLLMStreamingDelta) -> Self {
     Self {
+      r#type: "textDelta".to_string(),
       response_id: value.response_id,
       created_at: value.created_at.map(|c| c as u32),
-      delta: value.delta,
+      text_delta: value.delta,
       stop: value.stop,
     }
   }
@@ -753,20 +757,23 @@ impl From<NativeLLMStreamingDelta> for LLMStreamingDelta {
 #[napi(object)]
 #[derive(Debug, Clone)]
 pub struct LLMThinkingDelta {
+  #[napi(js_name = "type", ts_type = "\"thinkingDelta\"")]
+  pub r#type: String,
   /// Identifier of the response this delta belongs to.
   pub response_id: String,
   /// Unix timestamp of the response, when provided by the API.
   pub created_at: Option<u32>,
   /// Chunk of reasoning text, if any.
-  pub delta: Option<String>,
+  pub thinking_delta: Option<String>,
 }
 
 impl From<NativeLLMThinkingDelta> for LLMThinkingDelta {
   fn from(value: NativeLLMThinkingDelta) -> Self {
     Self {
+      r#type: "thinkingDelta".to_string(),
       response_id: value.response_id,
       created_at: value.created_at.map(|c| c as u32),
-      delta: value.delta,
+      thinking_delta: value.delta,
     }
   }
 }
@@ -775,6 +782,8 @@ impl From<NativeLLMThinkingDelta> for LLMThinkingDelta {
 #[napi(object)]
 #[derive(Debug, Clone)]
 pub struct LLMToolDelta {
+  #[napi(js_name = "type", ts_type = "\"toolDelta\"")]
+  pub r#type: String,
   /// Identifier for the in-progress tool call.
   pub tool_call_id: String,
   /// Name of the tool being called.
@@ -787,6 +796,8 @@ pub struct LLMToolDelta {
 #[napi(object)]
 #[derive(Debug, Clone)]
 pub struct LLMStreamingComplete {
+  #[napi(js_name = "type", ts_type = "\"complete\"")]
+  pub r#type: String,
   /// Provider-generated response identifier.
   pub id: String,
   /// Unix timestamp of the response, when provided by the API.
@@ -804,34 +815,11 @@ pub struct LLMStreamingComplete {
 }
 
 /// A single item emitted by a streaming LLM response.
-#[napi]
+#[napi(transparent)]
 #[derive(Debug, Clone)]
-pub enum LLMStreamingResponse {
-  /// A chunk of generated text.
-  Delta(LLMStreamingDelta),
-  /// A chunk of tool call arguments.
-  ToolDelta(LLMToolDelta),
-  /// A chunk of reasoning text.
-  ThinkingDelta(LLMThinkingDelta),
-  /// The final aggregated response.
-  Complete(LLMStreamingComplete),
-}
-
-#[napi]
-/// Get the streaming response out of a streamed chunk in the Llm.streamResponse method.
-///
-/// @param chunk - An LLMStreamingResponse chunk
-/// @returns A `LLMStreamingDelta`, `LLMToolDelta`, `LLMThinkingDelta` or a `LLMStreamingComplete` message, based on the content of the chunk.
-pub fn streaming_response(
-  chunk: LLMStreamingResponse,
-) -> Either4<LLMStreamingDelta, LLMToolDelta, LLMThinkingDelta, LLMStreamingComplete> {
-  match chunk {
-    LLMStreamingResponse::Delta(d) => Either4::A(d.clone()),
-    LLMStreamingResponse::ToolDelta(t) => Either4::B(t.clone()),
-    LLMStreamingResponse::ThinkingDelta(t) => Either4::C(t.clone()),
-    LLMStreamingResponse::Complete(c) => Either4::D(c.clone()),
-  }
-}
+pub struct LLMStreamingResponse(
+  pub Either4<LLMStreamingDelta, LLMToolDelta, LLMThinkingDelta, LLMStreamingComplete>,
+);
 
 impl From<NativeLLMStreamingResponse> for LLMStreamingResponse {
   fn from(value: NativeLLMStreamingResponse) -> Self {
@@ -851,13 +839,15 @@ impl From<NativeLLMStreamingResponse> for LLMStreamingResponse {
         if let Some(tc) = c.tool_calls {
           for t in tc {
             tool_calls.get_or_insert_with(Vec::new).push(ToolCallPart {
+              r#type: "toolCall".to_string(),
               id: t.id,
               name: t.name,
               arguments: t.arguments,
             });
           }
         }
-        Self::Complete(LLMStreamingComplete {
+        Self(Either4::D(LLMStreamingComplete {
+          r#type: "complete".to_string(),
           id: c.id,
           created_at: c.created_at.map(|c| c as u32),
           message: c.message.into(),
@@ -871,17 +861,16 @@ impl From<NativeLLMStreamingResponse> for LLMStreamingResponse {
             other_tokens: u.other_tokens,
           }),
           tool_calls,
-        })
+        }))
       }
-      NativeLLMStreamingResponse::Delta(d) => LLMStreamingResponse::Delta(d.into()),
-      NativeLLMStreamingResponse::ThinkingDelta(td) => {
-        LLMStreamingResponse::ThinkingDelta(td.into())
-      }
-      NativeLLMStreamingResponse::ToolDelta(td) => LLMStreamingResponse::ToolDelta(LLMToolDelta {
+      NativeLLMStreamingResponse::Delta(d) => Self(Either4::A(d.into())),
+      NativeLLMStreamingResponse::ThinkingDelta(td) => Self(Either4::C(td.into())),
+      NativeLLMStreamingResponse::ToolDelta(td) => Self(Either4::B(LLMToolDelta {
+        r#type: "toolDelta".to_string(),
         tool_call_id: td.tool_call_id,
         name: td.name,
         partial_arguments: td.partial_arguments,
-      }),
+      })),
     }
   }
 }


### PR DESCRIPTION
A few improvements:

- `MessagePart` is now a discriminated union of the various parts, no longer an enum with `kind` and `field0`. Constructor for plain objects (text, tool call, tool result, thinking) are removed
- `LLMStreamingResponse` is also a discriminated union of the various streaming items. `streamingResponse` getter was removed.

This improves the type inference experience and avoid workaround like `@ts-ignore` or type casting.
