### PR TITLE
Fix request defaults and provider stream handling

### DIFF
--- a/crates/llms-sdk/src/anthropic.rs
+++ b/crates/llms-sdk/src/anthropic.rs
@@ -125,15 +125,21 @@ pub struct AntToolCallPart {
     part_type: String,
 }
 
-impl From<ToolCallPart> for AntToolCallPart {
-    fn from(value: ToolCallPart) -> Self {
-        Self {
+impl TryFrom<ToolCallPart> for AntToolCallPart {
+    type Error = InvalidAntRequestConversion;
+
+    fn try_from(value: ToolCallPart) -> Result<Self, Self::Error> {
+        let input = serde_json::from_str(&value.arguments).map_err(|error| {
+            InvalidAntRequestConversion {
+                reason: format!("tool call arguments must be a JSON object: {error}"),
+            }
+        })?;
+        Ok(Self {
             id: value.id,
             name: value.name,
-            input: serde_json::from_str(&value.arguments)
-                .expect("Arguments should be JSON serializable"),
+            input,
             part_type: "tool_use".to_string(),
-        }
+        })
     }
 }
 
@@ -325,7 +331,7 @@ pub struct AntMessage {
 }
 
 impl TryFrom<Message> for AntMessage {
-    type Error = UnsupportedPartType;
+    type Error = InvalidAntRequestConversion;
 
     fn try_from(value: Message) -> Result<Self, Self::Error> {
         let role = AntMessageRole::from(value.role);
@@ -345,7 +351,7 @@ impl TryFrom<Message> for AntMessage {
                     content.push(AntMessagePart::Image(AntImagePart::from(i)));
                 }
                 MessagePart::ToolCall(tc) => {
-                    content.push(AntMessagePart::ToolCall(AntToolCallPart::from(tc)));
+                    content.push(AntMessagePart::ToolCall(AntToolCallPart::try_from(tc)?));
                 }
                 MessagePart::ToolResult(tr) => {
                     content.push(AntMessagePart::ToolResult(AntToolResultPart::from(tr)));
@@ -354,7 +360,8 @@ impl TryFrom<Message> for AntMessage {
                     return Err(UnsupportedPartType {
                         part_type: "audio".to_string(),
                         api_type: ApiType::Anthropic.to_string(),
-                    });
+                    }
+                    .into());
                 }
             }
         }
@@ -525,7 +532,7 @@ impl TryFrom<LLMRequest> for AntRequest {
 
     fn try_from(value: LLMRequest) -> Result<Self, Self::Error> {
         let mut messages = vec![];
-        let mut system = None;
+        let mut system: Option<String> = None;
         for m in value.messages {
             let message = AntMessage::try_from(m)?;
             match message.role {
@@ -537,7 +544,12 @@ impl TryFrom<LLMRequest> for AntRequest {
                             _ => continue,
                         }
                     }
-                    system = Some(text)
+                    if let Some(system) = &mut system {
+                        system.push('\n');
+                        system.push_str(&text);
+                    } else {
+                        system = Some(text);
+                    }
                 }
                 _ => messages.push(message),
             }
@@ -846,7 +858,7 @@ impl AntClient {
         &self,
         request: LLMRequest,
     ) -> Result<LLMResponse, Box<dyn std::error::Error>> {
-        let base_url = request.base_url.clone().unwrap();
+        let base_url = request.base_url_or_default();
         let api_key = request.api_key.clone();
         if request.stream {
             return Err(StreamParamError {
@@ -893,7 +905,7 @@ impl AntClient {
         &self,
         request: LLMRequest,
     ) -> Result<LLMStream, Box<dyn std::error::Error + Send + Sync>> {
-        let base_url = request.base_url.clone().unwrap();
+        let base_url = request.base_url_or_default();
         let api_key = request.api_key.clone();
         if !request.stream {
             return Err(StreamParamError {
@@ -1170,6 +1182,22 @@ mod tests {
     }
 
     #[test]
+    fn ant_message_rejects_invalid_tool_call_arguments() {
+        for arguments in ["not json", "[]"] {
+            let msg = Message {
+                role: MessageRole::Assistant,
+                content: vec![MessagePart::ToolCall(ToolCallPart {
+                    id: "call_1".to_string(),
+                    name: "tool".to_string(),
+                    arguments: arguments.to_string(),
+                })],
+            };
+
+            assert!(AntMessage::try_from(msg).is_err());
+        }
+    }
+
+    #[test]
     fn ant_message_part_roundtrip_text() {
         let _original = MessagePart::Text(TextPart {
             text: "roundtrip".to_string(),
@@ -1245,6 +1273,37 @@ mod tests {
         let ant_req = AntRequest::try_from(request).unwrap();
         assert_eq!(ant_req.system, Some("system prompt".to_string()));
         assert_eq!(ant_req.messages.len(), 1);
+    }
+
+    #[test]
+    fn ant_request_preserves_all_system_messages() {
+        let request = LLMRequest {
+            api_type: ApiType::Anthropic,
+            base_url: Some("https://api.anthropic.com/v1".to_string()),
+            api_key: "key".to_string(),
+            model: "claude".to_string(),
+            messages: vec![
+                text_message(MessageRole::System, "First instruction."),
+                text_message(MessageRole::System, "Second instruction."),
+                text_message(MessageRole::User, "hi"),
+            ],
+            max_output_tokens: None,
+            temperature: None,
+            top_p: None,
+            reasoning_effort: None,
+            prompt_cache_ttl: None,
+            stream: false,
+            output_format: None,
+            tools: None,
+            tool_choice: None,
+            parallel_tool_calls: false,
+        };
+
+        let ant_req = AntRequest::try_from(request).unwrap();
+        assert_eq!(
+            ant_req.system,
+            Some("First instruction.\nSecond instruction.".to_string())
+        );
     }
 
     #[test]

--- a/crates/llms-sdk/src/openai.rs
+++ b/crates/llms-sdk/src/openai.rs
@@ -801,7 +801,7 @@ impl OpenAIClient {
         &self,
         request: LLMRequest,
     ) -> Result<LLMResponse, Box<dyn std::error::Error>> {
-        let base_url = request.base_url.clone().unwrap();
+        let base_url = request.base_url_or_default();
         let api_key = request.api_key.clone();
         if request.stream {
             return Err(StreamParamError {
@@ -847,7 +847,7 @@ impl OpenAIClient {
         &self,
         request: LLMRequest,
     ) -> Result<LLMStream, Box<dyn std::error::Error + Send + Sync>> {
-        let base_url = request.base_url.clone().unwrap();
+        let base_url = request.base_url_or_default();
         let api_key = request.api_key.clone();
         if !request.stream {
             return Err(StreamParamError {
@@ -903,6 +903,10 @@ impl OpenAIClient {
                 match ev {
                     Ok(event) => {
                         if event.data == "[DONE]" {
+                            let Some(response_id) = response_id.clone() else {
+                                yield Err("OpenAI stream ended without a response ID".into());
+                                return;
+                            };
                             let mut tool_calls = None;
                             if !indexed_tool_calls.is_empty() {
                                 for (_, tc) in indexed_tool_calls.clone() {
@@ -913,7 +917,8 @@ impl OpenAIClient {
                                 }
                             }
                             let message = deltas_to_message(&deltas, tool_calls.as_deref());
-                            yield Ok(LLMStreamingResponse::Complete(LLMStreamingComplete { id: response_id.clone().unwrap(), deltas: deltas.clone(), created_at: first_created, usage: resp_usage.clone(), message, tool_calls, thinking_deltas: None }))
+                            yield Ok(LLMStreamingResponse::Complete(LLMStreamingComplete { id: response_id, deltas: deltas.clone(), created_at: first_created, usage: resp_usage.clone(), message, tool_calls, thinking_deltas: None }));
+                            return;
                         } else {
                             let json_result: Result<OpenAIStreamingMessage, serde_json::Error> = serde_json::from_str(&event.data);
                             match json_result {
@@ -956,6 +961,7 @@ impl OpenAIClient {
                     }
                 }
             }
+            yield Err("OpenAI stream ended before [DONE]".into());
         });
 
         Ok(s)
@@ -966,6 +972,12 @@ impl OpenAIClient {
 mod tests {
     use super::*;
     use crate::ThinkingPart;
+    use futures_util::StreamExt;
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+        thread,
+    };
 
     fn text_message(role: MessageRole, text: &str) -> Message {
         Message {
@@ -1409,5 +1421,57 @@ mod tests {
                 _ => panic!("There should not be any parts apart from tool calls and texts"),
             }
         }
+    }
+
+    #[tokio::test]
+    async fn openai_stream_errors_when_connection_closes_before_done() {
+        crate::install_crypto_provider();
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let body = concat!(
+            "data: {\"id\":\"stream_1\",\"created\":1,\"choices\":[{\"index\":0,",
+            "\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}],\"usage\":null}\n\n"
+        );
+        let server = thread::spawn(move || {
+            let (mut connection, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            connection.read(&mut request).unwrap();
+            write!(
+                connection,
+                "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+        });
+
+        let request = LLMRequest {
+            api_type: ApiType::OpenAI,
+            base_url: Some(format!("http://{address}")),
+            api_key: "key".to_string(),
+            model: "gpt-4".to_string(),
+            messages: vec![text_message(MessageRole::User, "hi")],
+            max_output_tokens: None,
+            temperature: None,
+            top_p: None,
+            reasoning_effort: None,
+            prompt_cache_ttl: None,
+            stream: true,
+            output_format: None,
+            tools: None,
+            tool_choice: None,
+            parallel_tool_calls: false,
+        };
+
+        let mut stream = OpenAIClient::new(RetryPolicy::default())
+            .stream_response(request)
+            .await
+            .unwrap();
+        assert!(matches!(
+            stream.next().await,
+            Some(Ok(LLMStreamingResponse::Delta(_)))
+        ));
+        assert!(stream.next().await.unwrap().is_err());
+        server.join().unwrap();
     }
 }

--- a/crates/llms-sdk/src/types.rs
+++ b/crates/llms-sdk/src/types.rs
@@ -421,6 +421,15 @@ impl Display for ApiType {
     }
 }
 
+impl ApiType {
+    fn default_base_url(self) -> &'static str {
+        match self {
+            Self::Anthropic => DEFAULT_ANTHROPIC_BASE_URL,
+            Self::OpenAI => DEFAULT_OPENAI_BASE_URL,
+        }
+    }
+}
+
 /// Amount of reasoning effort requested from the model.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
@@ -730,10 +739,7 @@ impl LLMRequestBuilder {
         if let Some(url) = &self.base_url {
             url.to_owned()
         } else {
-            match self.api_type {
-                ApiType::Anthropic => DEFAULT_ANTHROPIC_BASE_URL.to_owned(),
-                ApiType::OpenAI => DEFAULT_OPENAI_BASE_URL.to_owned(),
-            }
+            self.api_type.default_base_url().to_owned()
         }
     }
 
@@ -760,6 +766,12 @@ impl LLMRequestBuilder {
 }
 
 impl LLMRequest {
+    pub(crate) fn base_url_or_default(&self) -> String {
+        self.base_url
+            .clone()
+            .unwrap_or_else(|| self.api_type.default_base_url().to_owned())
+    }
+
     pub fn builder() -> LLMRequestBuilder {
         LLMRequestBuilder::new()
     }
@@ -931,6 +943,31 @@ mod tests {
     #[test]
     fn is_valid_json_rejects_incomplete_object() {
         assert!(!is_valid_json(r#"{"key": "value""#));
+    }
+
+    #[test]
+    fn request_without_base_url_uses_the_provider_default() {
+        let mut request = LLMRequest {
+            api_type: ApiType::OpenAI,
+            base_url: None,
+            api_key: "key".to_string(),
+            model: "model".to_string(),
+            messages: vec![],
+            max_output_tokens: None,
+            temperature: None,
+            top_p: None,
+            reasoning_effort: None,
+            prompt_cache_ttl: None,
+            stream: false,
+            output_format: None,
+            tools: None,
+            tool_choice: None,
+            parallel_tool_calls: false,
+        };
+
+        assert_eq!(request.base_url_or_default(), DEFAULT_OPENAI_BASE_URL);
+        request.api_type = ApiType::Anthropic;
+        assert_eq!(request.base_url_or_default(), DEFAULT_ANTHROPIC_BASE_URL);
     }
 
     #[test]


### PR DESCRIPTION
### Summary

- Resolve missing `base_url` values to provider defaults instead of panicking.
- Return `InvalidAntRequestConversion` for invalid or non-object Anthropic tool-call arguments.
- Preserve multiple Anthropic system messages with newline separation.
- Return errors for OpenAI SSE streams that end before `[DONE]`.
- Return an error if OpenAI sends `[DONE]` without a response ID.

### Tests

Added regression coverage for:

- Default provider base URL resolution.
- Invalid and non-object Anthropic tool-call arguments.
- Multiple Anthropic system messages with newline separation.
- OpenAI SSE EOF before `[DONE]` using a local HTTP test server.

### Validation

- `cargo fmt --all`
- `cargo check --workspace --all-features`
- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo test -p llms-sdk --release --all-features`

**Result:** 59 core SDK tests passed.