### PR TITLE
feat: add new message constructor methods and parse API for structured output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llms-sdk"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-stream",
  "base64",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "llms-sdk-py"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64",
  "either",

--- a/crates/llms-sdk-py/Cargo.toml
+++ b/crates/llms-sdk-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llms-sdk-py"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "MIT"
 readme = "README.md"

--- a/crates/llms-sdk-py/src/lib.rs
+++ b/crates/llms-sdk-py/src/lib.rs
@@ -30,6 +30,7 @@ mod llms_sdk_py {
     use llms_sdk::LLMThinkingDelta;
     use llms_sdk::LLMToolDelta;
     use pyo3::exceptions::PyStopAsyncIteration;
+    use pyo3::types::PyType;
     use pyo3_async_runtimes::tokio::future_into_py;
     use pyo3_stub_gen::derive::*;
     use std::collections::HashMap;
@@ -59,7 +60,6 @@ mod llms_sdk_py {
     };
     use pyo3::exceptions::PyRuntimeError;
     use pyo3::types::PyList;
-    use pyo3::types::PyType;
     use pyo3::{
         exceptions::{PyAttributeError, PyKeyError, PyValueError},
         prelude::*,
@@ -1311,6 +1311,57 @@ mod llms_sdk_py {
         fn new(role: String, content: Vec<MessagePart>) -> PyResult<Self> {
             let rl = MessageRole::new(role)?;
             Ok(Self { role: rl, content })
+        }
+
+        /// Build a user Message from a prompt.
+        ///
+        /// Args:
+        ///     prompt (str): Prompt for the message
+        /// Returns:
+        ///     Message: the built user-message, with the specified prompt
+        #[classmethod]
+        fn from_prompt(_cls: &Bound<'_, PyType>, prompt: String) -> Self {
+            Self {
+                role: MessageRole::User,
+                content: vec![text_part(prompt)],
+            }
+        }
+
+        /// Build a system Message from a prompt.
+        ///
+        /// Args:
+        ///     system (str): System prompt for the message
+        /// Returns:
+        ///     Message: the built system message, with the specified system prompt
+        #[classmethod]
+        fn from_system(_cls: &Bound<'_, PyType>, system: String) -> Self {
+            Self {
+                role: MessageRole::System,
+                content: vec![text_part(system)],
+            }
+        }
+
+        /// Build a Message from text content, with an optional role (defaults to user)
+        ///
+        /// Args:
+        ///     content (str): Text content for the message
+        ///     role (str | None): Role for the message
+        /// Returns:
+        ///     Message: the built system message, with the specified system prompt
+        #[classmethod]
+        fn from_string(
+            _cls: &Bound<'_, PyType>,
+            content: String,
+            role: Option<String>,
+        ) -> PyResult<Self> {
+            let message_role = match role {
+                Some(v) => MessageRole::new(v)?,
+                None => MessageRole::User,
+            };
+            Ok(Self {
+                role: message_role,
+                content: vec![text_part(content)],
+            })
         }
 
         /// The role of this message.

--- a/crates/llms-sdk-ts/index.d.ts
+++ b/crates/llms-sdk-ts/index.d.ts
@@ -268,6 +268,9 @@ export interface RetryPolicy {
   base: number
 }
 
+/** Build a text message, with an optional role (defaults to user if left undefined). */
+export declare function textMessage(content: string, role?: MessageRole | undefined | null): Message
+
 /** Plain-text segment of a message. */
 export interface TextPart {
   type: 'text'

--- a/crates/llms-sdk-ts/index.js
+++ b/crates/llms-sdk-ts/index.js
@@ -80,8 +80,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-android-arm64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -96,8 +96,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-android-arm-eabi')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -116,8 +116,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-win32-x64-msvc')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -132,8 +132,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-win32-ia32-msvc')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -148,8 +148,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-win32-arm64-msvc')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
     try {
       const binding = require('@cle-does-things/llms-sdk-darwin-universal')
       const bindingPackageVersion = require('@cle-does-things/llms-sdk-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -183,8 +183,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-darwin-x64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -199,8 +199,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-darwin-arm64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -219,8 +219,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-freebsd-x64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -235,8 +235,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-freebsd-arm64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -256,8 +256,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-x64-musl')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -272,8 +272,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-x64-gnu')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -290,8 +290,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-arm64-musl')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -306,8 +306,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-arm64-gnu')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -324,8 +324,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-arm-musleabihf')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -340,8 +340,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -358,8 +358,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-loong64-musl')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -374,8 +374,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-loong64-gnu')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -392,8 +392,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-riscv64-musl')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -408,8 +408,8 @@ function requireNative() {
         try {
           const binding = require('@cle-does-things/llms-sdk-linux-riscv64-gnu')
           const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -425,8 +425,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-linux-ppc64-gnu')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -441,8 +441,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-linux-s390x-gnu')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -461,8 +461,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-openharmony-arm64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -477,8 +477,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-openharmony-x64')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -493,8 +493,8 @@ function requireNative() {
       try {
         const binding = require('@cle-does-things/llms-sdk-openharmony-arm')
         const bindingPackageVersion = require('@cle-does-things/llms-sdk-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -565,4 +565,5 @@ module.exports.documentPart = nativeBinding.documentPart
 module.exports.imagePart = nativeBinding.imagePart
 module.exports.MessageRole = nativeBinding.MessageRole
 module.exports.ReasoningEffort = nativeBinding.ReasoningEffort
+module.exports.textMessage = nativeBinding.textMessage
 module.exports.ToolChoice = nativeBinding.ToolChoice

--- a/crates/llms-sdk-ts/package.json
+++ b/crates/llms-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cle-does-things/llms-sdk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Unified interface to call OpenAI and Anthropic-compatible LLM APIs from Typescript",
   "main": "index.js",
   "repository": {

--- a/crates/llms-sdk-ts/src/types.rs
+++ b/crates/llms-sdk-ts/src/types.rs
@@ -532,6 +532,19 @@ pub struct Message {
   pub content: Vec<MessagePart>,
 }
 
+/// Build a text message, with an optional role (defaults to user if left undefined).
+#[napi]
+pub fn text_message(content: String, role: Option<MessageRole>) -> Message {
+  let message_role = role.map_or(MessageRole::User, |r| r);
+  Message {
+    role: message_role,
+    content: vec![MessagePart(Either7::A(TextPart {
+      text: content,
+      r#type: "text".to_string(),
+    }))],
+  }
+}
+
 impl From<Message> for NativeMessage {
   fn from(value: Message) -> Self {
     let mut content: Vec<NativeMessagePart> = vec![];

--- a/crates/llms-sdk-wasm/src/types.rs
+++ b/crates/llms-sdk-wasm/src/types.rs
@@ -183,6 +183,15 @@ pub struct Message {
     content: Vec<MessagePart>,
 }
 
+/// Build a text message, with an optional role (defaults to user if left undefined).
+#[wasm_bindgen(js_name = textMessage)]
+pub fn text_message(content: String, role: Option<MessageRole>) -> Message {
+    Message {
+        role: role.unwrap_or(MessageRole::User),
+        content: vec![MessagePart::Text(TextPart { text: content })],
+    }
+}
+
 impl From<MessagePart> for NativeMessagePart {
     fn from(value: MessagePart) -> Self {
         match value {

--- a/crates/llms-sdk/Cargo.toml
+++ b/crates/llms-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llms-sdk"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "MIT"
 readme = "README.md"

--- a/crates/llms-sdk/src/types.rs
+++ b/crates/llms-sdk/src/types.rs
@@ -2,6 +2,7 @@ use base64::prelude::*;
 use futures_core::Stream;
 use reqwest_retry::Jitter;
 use schemars::{JsonSchema, Schema, schema_for, schema_for_value};
+use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 #[cfg(feature = "fs")]
 #[cfg(not(target_arch = "wasm32"))]
@@ -395,6 +396,61 @@ pub enum MessagePart {
 pub struct Message {
     pub role: MessageRole,
     pub content: Vec<MessagePart>,
+}
+
+impl Message {
+    /// Build a user message from a text prompt.
+    pub fn from_prompt(prompt: impl Into<String>) -> Self {
+        Self {
+            role: MessageRole::User,
+            content: vec![MessagePart::Text(TextPart {
+                text: prompt.into(),
+            })],
+        }
+    }
+
+    /// Build a system message from a text system prompt
+    pub fn from_system(system: impl Into<String>) -> Self {
+        Self {
+            role: MessageRole::System,
+            content: vec![MessagePart::Text(TextPart {
+                text: system.into(),
+            })],
+        }
+    }
+
+    /// Build a message, with an optional role (defaults to user), from text content.
+    pub fn from_string(content: impl Into<String>, role: Option<MessageRole>) -> Self {
+        Self {
+            role: role.map_or(MessageRole::User, |r| r),
+            content: vec![MessagePart::Text(TextPart {
+                text: content.into(),
+            })],
+        }
+    }
+
+    /// Parse a message into the `struct` its structured output shape should correspond to.
+    pub fn parse<T: DeserializeOwned>(&self) -> Result<T, Box<dyn std::error::Error>> {
+        let text_parts: Vec<MessagePart> = self
+            .content
+            .iter()
+            .filter(|&f| matches!(f, MessagePart::Text(_)))
+            .cloned()
+            .collect();
+        if text_parts.is_empty() {
+            return Err("No text parts were produced by the LLM, one expected".into());
+        } else if text_parts.len() > 1 {
+            return Err("Multiple text parts were produced by the LLM, only one expected".into());
+        }
+        let text = text_parts
+            .first()
+            .expect("The vector should have length of 1");
+        if let MessagePart::Text(t) = text {
+            let val: T = serde_json::from_str(&t.text)?;
+            return Ok(val);
+        }
+        Err("The parts are not text".into())
+    }
 }
 
 /// Supported LLM API provider.
@@ -1059,5 +1115,58 @@ mod tests {
         let part = DocumentPart::try_from_pdf_file("files/file.pdf".to_string()).unwrap();
         assert_eq!(part.mime_type, Some("application/pdf".to_string()));
         assert!(part.is_base64);
+    }
+
+    #[test]
+    fn test_message_from_prompt() {
+        let message = Message::from_prompt("text");
+        assert_eq!(message.role, MessageRole::User);
+        assert!(matches!(message.content[0], MessagePart::Text(ref t) if t.text == "text"));
+    }
+
+    #[test]
+    fn test_message_from_system() {
+        let message = Message::from_system("text");
+        assert_eq!(message.role, MessageRole::System);
+        assert!(matches!(message.content[0], MessagePart::Text(ref t) if t.text == "text"));
+    }
+
+    #[test]
+    fn test_message_from_string_no_role() {
+        let message = Message::from_string("text", None);
+        assert_eq!(message.role, MessageRole::User);
+        assert!(matches!(message.content[0], MessagePart::Text(ref t) if t.text == "text"));
+    }
+
+    #[test]
+    fn test_message_from_string_w_role() {
+        let message = Message::from_string("text", Some(MessageRole::Assistant));
+        assert_eq!(message.role, MessageRole::Assistant);
+        assert!(matches!(message.content[0], MessagePart::Text(ref t) if t.text == "text"));
+    }
+
+    #[test]
+    fn test_parse_message() {
+        #[derive(Debug, Serialize, Deserialize)]
+        struct ToParse {
+            text: String,
+            number: u64,
+            boolean: bool,
+            float: f32,
+        }
+
+        let text = serde_json::to_string(&ToParse {
+            text: "hello".to_string(),
+            number: 3,
+            boolean: false,
+            float: 0.3,
+        })
+        .expect("Should be able to serialize");
+        let msg = Message::from_string(text, Some(MessageRole::Assistant));
+        let parsed: ToParse = msg.parse().expect("Should parse correctly");
+        assert_eq!(parsed.text, "hello");
+        assert_eq!(parsed.boolean, false);
+        assert_eq!(parsed.float, 0.3);
+        assert_eq!(parsed.number, 3);
     }
 }

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -48,14 +48,18 @@ A single interface for **OpenAI-compatible chat completions** and the **Anthropi
 <Tabs>
   <TabItem label="Rust">
     ```rust
-    use llms_sdk::{LLM, LLMRequest, Message, MessagePart, MessageRole, TextPart};
+    use llms_sdk::{LLM, LLMRequest, Message};
 
     let request = LLMRequest::builder()
         .api_key(std::env::var("OPENAI_API_KEY")?)
-        .messages(vec![Message {
-            role: MessageRole::User,
-            content: vec![MessagePart::Text(TextPart::new("Hello!"))],
-        }])
+        .messages(vec![
+          Message::from_prompt("Hello!")
+          // This is equivalent to:
+          // Message {
+          //    role: MessageRole::User,
+          //    content: vec![MessagePart::Text(TextPart::new("Hello!"))],
+          // }
+        ])
         .model("gpt-5.4-mini")
         .build();
 
@@ -71,10 +75,14 @@ A single interface for **OpenAI-compatible chat completions** and the **Anthropi
       apiType: ApiType.OpenAI,
       apiKey: process.env.OPENAI_API_KEY!,
       model: 'gpt-5.4-mini',
-      messages: [{
-        role: MessageRole.User,
-        content: [{ text: 'Hello!', type: 'text' }],
-      }],
+      messages: [
+        textMessage("Hello!")
+        // This is equivalent to:
+        // {
+        //  role: MessageRole.User,
+        //  content: [{ text: 'Hello!', type: 'text' }],
+        // }
+      ],
       stream: false,
       parallelToolCalls: false,
     }
@@ -90,12 +98,38 @@ A single interface for **OpenAI-compatible chat completions** and the **Anthropi
     request = LLMRequest(
         model="gpt-5.4-mini",
         api_key="sk-...",
-        messages=[Message("user", [TextPart("Hello, world!")])],
+        messages=[
+          Message.from_prompt("Hello!"),
+          # This is equivalent to:
+          # Message("user", [TextPart("Hello, world!")])
+        ],
         stream=False,
     )
 
     client = llm.LLM()
     response = await client.respond(request)
     ```
+  </TabItem>
+  <TabItem label="WASM">
+      ```javascript
+      import init, { chat } from "@cle-does-things/llms-sdk-wasm";
+      
+      await init();
+      
+      const response = await chat({
+        api_type: "openai",
+        api_key: "sk-...",
+        model: "gpt-5.4-mini",
+        messages: [
+          textmessage("Hello!")
+          // This is equivalent to:
+          // { role: "user", content: [{ type: "text", text: "Hello!" }] }
+        ],
+        stream: false,
+        parallel_tool_calls: false,
+      });
+      
+      console.log(response.message.content);
+      ```
   </TabItem>
 </Tabs>

--- a/docs/src/content/docs/python.mdx
+++ b/docs/src/content/docs/python.mdx
@@ -28,7 +28,7 @@ async def main():
         model="gpt-5.4-mini",
         api_key="sk-...",
         messages=[
-            llm.Message("user", [llm.TextPart("Hello, world!")])
+            llm.Message.from_prompt("Hello!")
         ],
         stream=False,
     )
@@ -54,7 +54,7 @@ async def main():
     request = llm.LLMRequest(
         model="gpt-5.4-mini",
         api_key="sk-...",
-        messages=[llm.Message("user", [llm.TextPart("Count to 5")])],
+        messages=[llm.Message.from_prompt("Count to 5")],
         stream=True,
     )
 

--- a/docs/src/content/docs/rust.mdx
+++ b/docs/src/content/docs/rust.mdx
@@ -14,14 +14,14 @@ Add the crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-llms-sdk = "0.2"
+llms-sdk = "*"
 ```
 
 Enable optional features as needed:
 
 ```toml
 [dependencies]
-llms-sdk = { version = "0.2", features = ["cli"] }
+llms-sdk = { version = "*", features = ["cli"] }
 ```
 
 ## Quick start
@@ -36,10 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         base_url: None,
         api_key: std::env::var("OPENAI_API_KEY")?,
         model: "gpt-5.4-mini".to_string(),
-        messages: vec![Message {
-            role: MessageRole::User,
-            content: vec![MessagePart::Text(TextPart::new("Hello!"))],
-        }],
+        messages: vec![Message::from_prompt("Hello!")],
         max_output_tokens: Some(256),
         temperature: Some(0.7),
         top_p: None,
@@ -70,10 +67,7 @@ let request = LLMRequest::builder()
     .api_type(ApiType::Anthropic)
     .api_key(std::env::var("ANTHROPIC_API_KEY").unwrap())
     .model("claude-5-sonnet".to_string())
-    .messages(vec![Message {
-        role: MessageRole::User,
-        content: vec![MessagePart::Text(TextPart::new("Hi!"))],
-    }])
+    .messages(vec![Message::from_prompt("Hi!")])
     .max_output_tokens(256)
     .build();
 ```
@@ -146,6 +140,14 @@ let request = LLMRequest {
     }),
     ..request
 };
+```
+
+If you want to validate the response directly against the `struct` for which the schema was generated,
+use the `.parse(` method:
+
+```rust
+let response = llm.respond(request).await?;
+let validated: Capital = response.message.parse()?;
 ```
 
 ## Tool use

--- a/docs/src/content/docs/typescript.mdx
+++ b/docs/src/content/docs/typescript.mdx
@@ -21,7 +21,7 @@ If your platform is not covered, the package will attempt to build from source (
 ## Quick start
 
 ```typescript
-import { Llm, ApiType, MessageRole } from '@cle-does-things/llms-sdk'
+import { Llm, ApiType, textMessage } from '@cle-does-things/llms-sdk'
 
 async function main() {
   const request = {
@@ -29,10 +29,7 @@ async function main() {
     apiKey: process.env.OPENAI_API_KEY!,
     model: 'gpt-5.4-mini',
     messages: [
-      {
-        role: MessageRole.User,
-        content: [{ text: 'Hello!', type: 'text' }],
-      },
+      textMessage("Hello!"),
     ],
     maxOutputTokens: 256,
     temperature: 0.7,

--- a/docs/src/content/docs/wasm.mdx
+++ b/docs/src/content/docs/wasm.mdx
@@ -34,7 +34,7 @@ const response = await chat({
   api_key: "sk-...",
   model: "gpt-5.4-mini",
   messages: [
-    { role: "user", content: [{ type: "text", text: "Hello!" }] }
+    textmessage("Hello!")
   ],
   stream: false,
   parallel_tool_calls: false,
@@ -57,7 +57,7 @@ const request = {
   api_key: "sk-...",
   model: "gpt-5.4-mini",
   messages: [
-    { role: "user", content: [{ type: "text", text: "Count to 5" }] }
+    textmessage("Count to 5")
   ],
   stream: true,
   parallel_tool_calls: false,

--- a/packages/wasm/package-lock.json
+++ b/packages/wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cle-does-things/llms-sdk-wasm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cle-does-things/llms-sdk-wasm",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^5"

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cle-does-things/llms-sdk-wasm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Unified interface to call OpenAI and Anthropic-compatible LLM APIs from your browser",
   "type": "module",
   "main": "./pkg/llms_sdk_wasm.js",


### PR DESCRIPTION
Now you can parse messages into deserializable structs that represent the shape of the structured output, as well as construct messages from text with default roles
